### PR TITLE
{fix} - 회원 가입시 푸시 값 1로 설정 \n #249

### DIFF
--- a/src/features/auth/repository/v02GoogleOauthCallbackAuthRepository.go
+++ b/src/features/auth/repository/v02GoogleOauthCallbackAuthRepository.go
@@ -53,6 +53,7 @@ func (g *V02GoogleOauthCallbackAuthRepository) FindOneAndUpdateUser(ctx context.
 		user.Provider = "google"
 		user.Birth = "0000-01-01"
 		user.Name = "푸드픽"
+		user.Push = utils.PtrTrue()
 		result = g.GormDB.WithContext(ctx).Model(&user).Create(&user)
 		if result.Error != nil {
 			return nil, utils.ErrorMsg(ctx, utils.ErrInternalDB, utils.Trace(), fmt.Sprintf("유저 데이터 생성 실패 %v", result.Error), utils.ErrFromMysqlDB)

--- a/src/features/auth/usecase/useCase.go
+++ b/src/features/auth/usecase/useCase.go
@@ -20,6 +20,7 @@ func CreateGoogleUserDTO(oauthData utils.OAuthData) *mysql.Users {
 		Provider: "google",
 		Birth:    "1990-01-01",
 		Name:     "임시푸드픽",
+		Push:     utils.PtrTrue(),
 	}
 }
 
@@ -52,6 +53,7 @@ func CreateSignupUser(req *request.ReqSignup) mysql.Users {
 		Name:     req.Name,
 		Birth:    req.Birth,
 		Sex:      req.Sex,
+		Push:     utils.PtrTrue(),
 	}
 }
 

--- a/src/utils/env.go
+++ b/src/utils/env.go
@@ -102,3 +102,13 @@ func CtxGenerate(c echo.Context) (context.Context, uint, string) {
 	return ctx, userID, email
 
 }
+
+func PtrTrue() *bool {
+	b := true
+	return &b
+}
+
+func PtrFalse() *bool {
+	b := false
+	return &b
+}


### PR DESCRIPTION
This pull request introduces a new utility function and updates several user-related functions to include a new `Push` field set to `true` by default. The most important changes are outlined below:

### Utility functions:

* [`src/utils/env.go`](diffhunk://#diff-f48bd5d50ed6428cd8d1ea22b09ad70db376741f34bbce25b70fe1376787e2bcR105-R114): Added `PtrTrue` and `PtrFalse` utility functions to return pointers to boolean values.

### User-related updates:

* [`src/features/auth/repository/v02GoogleOauthCallbackAuthRepository.go`](diffhunk://#diff-caa0058b219e3f273e1ade4d65ca882e816213133403dd04d6b0659aa7d6af1dR56): Updated the `FindOneAndUpdateUser` method to set the `Push` field to `true` when creating a new user.
* [`src/features/auth/usecase/useCase.go`](diffhunk://#diff-8c3d7f6e422d40396b413ccf93b85373d6c0f511c064fc46b1bbc62f26eecddbR23): Modified the `CreateGoogleUserDTO` and `CreateSignupUser` functions to include the `Push` field set to `true` for new users. [[1]](diffhunk://#diff-8c3d7f6e422d40396b413ccf93b85373d6c0f511c064fc46b1bbc62f26eecddbR23) [[2]](diffhunk://#diff-8c3d7f6e422d40396b413ccf93b85373d6c0f511c064fc46b1bbc62f26eecddbR56)